### PR TITLE
fix(telescopes.py-get_energy_axis_function_delt): replace hard-coded …

### DIFF
--- a/dao2caom2/dao_name.py
+++ b/dao2caom2/dao_name.py
@@ -2,7 +2,7 @@
 # ******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 # *************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
 #
-#  (c) 2020.                            (c) 2020.
+#  (c) 2025.                            (c) 2025.
 #  Government of Canada                 Gouvernement du Canada
 #  National Research Council            Conseil national de recherches
 #  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
@@ -68,6 +68,7 @@
 
 import re
 
+from os.path import basename
 from caom2pipe import manage_composable as mc
 
 __all__ = ['DAOName', 'get_collection', 'PRODUCT_COLLECTION']
@@ -96,16 +97,10 @@ class DAOName(mc.StorageName):
 
     def __init__(
         self,
-        entry=None,
-        file_name=None,
         source_names=None,
     ):
-        if file_name is None:
-            file_name = mc.CaomName.extract_file_name(entry).replace('.header', '')
-        self._collection = get_collection(file_name)
-        if source_names is None:
-            source_names = [entry]
-        super().__init__(file_name=file_name, source_names=source_names)
+        self._collection = get_collection(basename(source_names[0]))
+        super().__init__(source_names=source_names)
 
     def _get_uri(self, file_name, scheme):
         return mc.build_uri(self._collection, file_name.replace('.gz', ''), scheme)

--- a/dao2caom2/data_source.py
+++ b/dao2caom2/data_source.py
@@ -2,7 +2,7 @@
 # ******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 # *************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
 #
-#  (c) 2021.                            (c) 2021.
+#  (c) 2025.                            (c) 2025.
 #  Government of Canada                 Gouvernement du Canada
 #  National Research Council            Conseil national de recherches
 #  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
@@ -73,17 +73,23 @@ from dao2caom2 import dao_name
 __all__ = ['DAOLocalFilesDataSource', 'DAOVaultDataSource']
 
 
-class DAOLocalFilesDataSource(dsc.LocalFilesDataSource):
-    def __init__(self, config, cadc_client, metadata_reader):
-        super().__init__(config, cadc_client, metadata_reader, config.recurse_data_sources)
+class DAOLocalFilesDataSource(dsc.LocalFilesDataSourceRunnerMeta):
+    def __init__(self, config, cadc_client):
+        super().__init__(
+            config,
+            cadc_client,
+            config.recurse_data_sources,
+            scheme=config.scheme,
+            storage_name_ctor=dao_name.DAOName,
+        )
 
     def get_collection(self, f_name):
         return dao_name.get_collection(f_name)
 
 
-class DAOVaultDataSource(dsc.VaultCleanupDataSource):
-    def __init__(self, config, vault_client, cadc_client, metadata_reader):
-        super().__init__(config, vault_client, cadc_client, metadata_reader, dao_name.DAOName)
+class DAOVaultDataSource(dsc.VaultCleanupDataSourceRunnerMeta):
+    def __init__(self, config, vault_client, cadc_client):
+        super().__init__(config, vault_client, cadc_client, dao_name.DAOName)
 
     def get_collection(self, f_name):
         return dao_name.get_collection(f_name)

--- a/dao2caom2/fits2caom2_augmentation.py
+++ b/dao2caom2/fits2caom2_augmentation.py
@@ -84,7 +84,7 @@ class DAOFits2caom2Visitor(cc.Fits2caom2VisitorRunnerMeta):
             data_product_type = DataProductType.SPECTRUM
         return data_product_type
 
-    def _get_mapping(self, dest_uri):
+    def _get_mappings(self, dest_uri):
         if self._storage_name.file_name.startswith('a'):
             result = telescopes.SkyCam(
                 self._storage_name, self._clients, self._reporter, self._observation, self._config
@@ -145,7 +145,7 @@ class DAOFits2caom2Visitor(cc.Fits2caom2VisitorRunnerMeta):
                     )
 
         self._logger.debug(f'Created {result.__class__.__name__} instance.')
-        return result
+        return [result]
 
 
 def visit(observation, **kwargs):

--- a/dao2caom2/fits2caom2_augmentation.py
+++ b/dao2caom2/fits2caom2_augmentation.py
@@ -71,9 +71,7 @@ from caom2 import DataProductType
 from dao2caom2 import telescopes, dao_name
 
 
-class DAOFits2caom2Visitor(cc.Fits2caom2Visitor):
-    def __init__(self, observation, **kwargs):
-        super().__init__(observation, **kwargs)
+class DAOFits2caom2Visitor(cc.Fits2caom2VisitorRunnerMeta):
 
     @staticmethod
     def get_data_product_type(headers):
@@ -86,68 +84,64 @@ class DAOFits2caom2Visitor(cc.Fits2caom2Visitor):
             data_product_type = DataProductType.SPECTRUM
         return data_product_type
 
-    def _get_mapping(self, headers, _):
+    def _get_mapping(self, dest_uri):
         if self._storage_name.file_name.startswith('a'):
             result = telescopes.SkyCam(
-                self._storage_name, headers, self._clients, self._observable, self._observation, self._config
+                self._storage_name, self._clients, self._reporter, self._observation, self._config
             )
         else:
-            data_product_type = DAOFits2caom2Visitor.get_data_product_type(headers)
+            data_product_type = DAOFits2caom2Visitor.get_data_product_type(self._storage_name.metadata.get(dest_uri))
             if data_product_type == DataProductType.IMAGE:
                 if dao_name.DAOName.is_processed(self._storage_name.file_id):
                     if self._storage_name.is_12_metre:
                         result = telescopes.Dao12MetreProcessedImage(
                             self._storage_name,
-                            headers,
                             self._clients,
-                            self._observable,
+                            self._reporter,
                             self._observation,
                             self._config,
                         )
                     else:
                         result = telescopes.Dao18MetreProcessedImage(
                             self._storage_name,
-                            headers,
                             self._clients,
-                            self._observable,
+                            self._reporter,
                             self._observation,
                             self._config,
                         )
                 elif self._storage_name.is_12_metre:
                     result = telescopes.Dao12MetreImage(
-                        self._storage_name, headers, self._clients, self._observable, self._observation, self._config
+                        self._storage_name, self._clients, self._reporter, self._observation, self._config
                     )
                 else:
                     result = telescopes.Dao18MetreImage(
-                        self._storage_name, headers, self._clients, self._observable, self._observation, self._config
+                        self._storage_name, self._clients, self._reporter, self._observation, self._config
                     )
             else:
                 if dao_name.DAOName.is_processed(self._storage_name.file_id):
                     if self._storage_name.is_12_metre:
                         result = telescopes.Dao12MetreProcessedSpectrum(
                             self._storage_name,
-                            headers,
                             self._clients,
-                            self._observable,
+                            self._reporter,
                             self._observation,
                             self._config,
                         )
                     else:
                         result = telescopes.Dao18MetreProcessedSpectrum(
                             self._storage_name,
-                            headers,
                             self._clients,
-                            self._observable,
+                            self._reporter,
                             self._observation,
                             self._config,
                         )
                 elif self._storage_name.is_12_metre:
                     result = telescopes.Dao12MetreSpectrum(
-                        self._storage_name, headers, self._clients, self._observable, self._observation, self._config
+                        self._storage_name, self._clients, self._reporter, self._observation, self._config
                     )
                 else:
                     result = telescopes.Dao18MetreSpectrum(
-                        self._storage_name, headers, self._clients, self._observable, self._observation, self._config
+                        self._storage_name, self._clients, self._reporter, self._observation, self._config
                     )
 
         self._logger.debug(f'Created {result.__class__.__name__} instance.')

--- a/dao2caom2/telescopes.py
+++ b/dao2caom2/telescopes.py
@@ -894,13 +894,11 @@ class ProcessedSpectrum(DAOTelescopeMapping):
 
 
 class Dao12MetreImage(Dao12Metre, Imaging):
-    def __init__(self, storage_name, clients, observable, observation, config):
-        super().__init__(storage_name, clients, observable, observation, config)
+    pass
 
 
 class Dao12MetreProcessedImage(Dao12MetreImage, ProcessedImage):
-    def __init__(self, storage_name, clients, observable, observation, config):
-        super().__init__(storage_name, clients, observable, observation, config)
+    pass
 
 
 class Dao12MetreSpectrum(Dao12Metre):
@@ -927,13 +925,11 @@ class Dao12MetreProcessedSpectrum(Dao12MetreSpectrum, ProcessedSpectrum):
 
 
 class Dao18MetreImage(Dao18Metre, Imaging):
-    def __init__(self, storage_name, clients, observable, observation, config):
-        super().__init__(storage_name, clients, observable, observation, config)
+    pass
 
 
 class Dao18MetreProcessedImage(Dao18MetreImage, ProcessedImage):
-    def __init__(self, storage_name, clients, observable, observation, config):
-        super().__init__(storage_name, clients, observable, observation, config)
+    pass
 
 
 class Dao18MetreSpectrum(Dao18Metre):

--- a/dao2caom2/tests/conftest.py
+++ b/dao2caom2/tests/conftest.py
@@ -2,7 +2,7 @@
 # ******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 # *************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
 #
-#  (c) 2022.                            (c) 2022.
+#  (c) 2025.                            (c) 2025.
 #  Government of Canada                 Gouvernement du Canada
 #  National Research Council            Conseil national de recherches
 #  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
@@ -93,3 +93,8 @@ def test_config():
 def test_data_dir():
     this_dir = dirname(realpath(__file__))
     return join(this_dir, 'data')
+
+
+@pytest.fixture()
+def change_test_dir(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)

--- a/dao2caom2/tests/data/dao_r122_1994_000008.expected.xml
+++ b/dao2caom2/tests/data/dao_r122_1994_000008.expected.xml
@@ -1,0 +1,140 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<caom2:Observation xmlns:caom2="http://www.opencadc.org/caom2/xml/v2.4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="caom2:SimpleObservation" caom2:id="0501ee5b-facf-4c44-81cc-718d040352b1" caom2:metaProducer="dao2caom22caom2/0.0.0">
+  <caom2:collection>DAO</caom2:collection>
+  <caom2:observationID>dao_r122_1994_000008</caom2:observationID>
+  <caom2:metaRelease>1994-02-11T03:52:37.000</caom2:metaRelease>
+  <caom2:algorithm>
+    <caom2:name>exposure</caom2:name>
+  </caom2:algorithm>
+  <caom2:type>object</caom2:type>
+  <caom2:intent>science</caom2:intent>
+  <caom2:target>
+    <caom2:name>Gam Gem</caom2:name>
+    <caom2:type>object</caom2:type>
+    <caom2:standard>false</caom2:standard>
+    <caom2:moving>false</caom2:moving>
+  </caom2:target>
+  <caom2:telescope>
+    <caom2:name>DAO 1.2-m</caom2:name>
+    <caom2:geoLocationX>-2331226.785412281</caom2:geoLocationX>
+    <caom2:geoLocationY>-3532798.9784666346</caom2:geoLocationY>
+    <caom2:geoLocationZ>4755607.337178416</caom2:geoLocationZ>
+  </caom2:telescope>
+  <caom2:instrument>
+    <caom2:name>McKellar Spectrograph</caom2:name>
+  </caom2:instrument>
+  <caom2:planes>
+    <caom2:plane caom2:id="2982443c-7242-4c39-ad24-ce44c48966ed" caom2:metaProducer="dao2caom22caom2/0.0.0">
+      <caom2:productID>dao_r122_1994_000008</caom2:productID>
+      <caom2:metaRelease>1994-02-11T03:52:37.000</caom2:metaRelease>
+      <caom2:dataRelease>1995-02-11T03:52:37.000</caom2:dataRelease>
+      <caom2:dataProductType>spectrum</caom2:dataProductType>
+      <caom2:calibrationLevel>1</caom2:calibrationLevel>
+      <caom2:provenance>
+        <caom2:name>DAO unprocessed data</caom2:name>
+        <caom2:project>DAO Science Archive</caom2:project>
+        <caom2:producer>NRC Herzberg</caom2:producer>
+        <caom2:reference>https://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/en/dao/</caom2:reference>
+      </caom2:provenance>
+      <caom2:artifacts>
+        <caom2:artifact caom2:id="73477552-b9e1-462f-aa0b-90f8a4b673e2" caom2:metaProducer="dao2caom22caom2/0.0.0">
+          <caom2:uri>cadc:DAO/dao_r122_1994_000008.fits</caom2:uri>
+          <caom2:productType>science</caom2:productType>
+          <caom2:releaseType>data</caom2:releaseType>
+          <caom2:contentType>application/fits</caom2:contentType>
+          <caom2:parts>
+            <caom2:part caom2:id="269bb722-b774-4600-a505-17b7de1044a4">
+              <caom2:name>0</caom2:name>
+              <caom2:chunks>
+                <caom2:chunk caom2:id="bacc4c54-2dda-4b44-b36c-09c5b318c8dc" caom2:metaProducer="dao2caom22caom2/0.0.0">
+                  <caom2:observable>
+                    <caom2:dependent>
+                      <caom2:axis>
+                        <caom2:ctype>FLUX</caom2:ctype>
+                        <caom2:cunit>COUNTS</caom2:cunit>
+                      </caom2:axis>
+                      <caom2:bin>1</caom2:bin>
+                    </caom2:dependent>
+                  </caom2:observable>
+                  <caom2:position>
+                    <caom2:axis>
+                      <caom2:axis1>
+                        <caom2:ctype>RA---TAN</caom2:ctype>
+                        <caom2:cunit>deg</caom2:cunit>
+                      </caom2:axis1>
+                      <caom2:axis2>
+                        <caom2:ctype>DEC--TAN</caom2:ctype>
+                        <caom2:cunit>deg</caom2:cunit>
+                      </caom2:axis2>
+                      <caom2:function>
+                        <caom2:dimension>
+                          <caom2:naxis1>1</caom2:naxis1>
+                          <caom2:naxis2>1</caom2:naxis2>
+                        </caom2:dimension>
+                        <caom2:refCoord>
+                          <caom2:coord1>
+                            <caom2:pix>1.0</caom2:pix>
+                            <caom2:val>99.42791666666666</caom2:val>
+                          </caom2:coord1>
+                          <caom2:coord2>
+                            <caom2:pix>1.0</caom2:pix>
+                            <caom2:val>16.399166666666666</caom2:val>
+                          </caom2:coord2>
+                        </caom2:refCoord>
+                        <caom2:cd11>-0.001388</caom2:cd11>
+                        <caom2:cd12>0.0</caom2:cd12>
+                        <caom2:cd21>0.0</caom2:cd21>
+                        <caom2:cd22>0.001388</caom2:cd22>
+                      </caom2:function>
+                    </caom2:axis>
+                    <caom2:coordsys>FK5</caom2:coordsys>
+                    <caom2:equinox>2000.0</caom2:equinox>
+                  </caom2:position>
+                  <caom2:energy>
+                    <caom2:axis>
+                      <caom2:axis>
+                        <caom2:ctype>WAVE</caom2:ctype>
+                        <caom2:cunit>m</caom2:cunit>
+                      </caom2:axis>
+                      <caom2:function>
+                        <caom2:naxis>2000</caom2:naxis>
+                        <caom2:delta>3.6e-12</caom2:delta>
+                        <caom2:refCoord>
+                          <caom2:pix>722.0</caom2:pix>
+                          <caom2:val>4.072e-07</caom2:val>
+                        </caom2:refCoord>
+                      </caom2:function>
+                    </caom2:axis>
+                    <caom2:specsys>TOPOCENT</caom2:specsys>
+                    <caom2:ssysobs>TOPOCENT</caom2:ssysobs>
+                    <caom2:ssyssrc>TOPOCENT</caom2:ssyssrc>
+                    <caom2:resolvingPower>45244.444444444445</caom2:resolvingPower>
+                  </caom2:energy>
+                  <caom2:time>
+                    <caom2:axis>
+                      <caom2:axis>
+                        <caom2:ctype>TIME</caom2:ctype>
+                        <caom2:cunit>d</caom2:cunit>
+                      </caom2:axis>
+                      <caom2:function>
+                        <caom2:naxis>1</caom2:naxis>
+                        <caom2:delta>0.04179398148148148</caom2:delta>
+                        <caom2:refCoord>
+                          <caom2:pix>0.5</caom2:pix>
+                          <caom2:val>49394.16153935185</caom2:val>
+                        </caom2:refCoord>
+                      </caom2:function>
+                    </caom2:axis>
+                    <caom2:timesys>UTC</caom2:timesys>
+                    <caom2:exposure>3611.0</caom2:exposure>
+                    <caom2:resolution>3611.0</caom2:resolution>
+                  </caom2:time>
+                </caom2:chunk>
+              </caom2:chunks>
+            </caom2:part>
+          </caom2:parts>
+        </caom2:artifact>
+      </caom2:artifacts>
+    </caom2:plane>
+  </caom2:planes>
+</caom2:Observation>

--- a/dao2caom2/tests/data/dao_r122_1994_000008.fits.header
+++ b/dao2caom2/tests/data/dao_r122_1994_000008.fits.header
@@ -1,0 +1,40 @@
+# HDU 0 in dao_r122_1994_000008.fits:
+SIMPLE  =                    T / conforms to FITS standard                      
+BITPIX  =                   16 / array data type                                
+NAXIS   =                    2 / number of array dimensions                     
+NAXIS1  =                 2000                                                  
+NAXIS2  =                    2                                                  
+OBJECT  = 'Gam Gem '           / OBJECT label                                   
+ITIME   =                 3611 / OBJECT INTEGRATION TIME                        
+BTIME   =                    5 / BASELINE INTEGRATION TIME                      
+UT      = '03:52:37'           / UT at start of exposure                        
+DATE-OBS= '1994-02-11T03:52:37' / UT date/time at start of exposure             
+RA      = '06:37:42.7'         / coordinates set by CDS Sesame service          
+DEC     = '+16:23:57'          / coordinates set by CDS Sesame service          
+LMDAREF =                 4072 / WAVELENGTH REFERENCE POINT                     
+PIXLREF =                  722 / CORRESPONDING PIXEL REFERENCE                  
+EXP-NBR =                    8 / ARCHIVE EXPOSURE NUMBER                        
+ORIGIN  = 'NRC HAARC'                                                           
+INSTRUME= 'McKellar Spectrograph'                                               
+TELESCOP= '1.2-m   '                                                            
+OBSERVER= 'sj adelman'                                                          
+DETECTOR= 'RETICON '                                                            
+PIXSIZE =                 15.0 / pixel size in microns                          
+DISPAXIS=                    1                                                  
+OBSERVAT= 'DAO     '                                                            
+OBSMODE = 'single-slit spectroscopy'                                            
+WAVELENG=                 4072                                                  
+REFPIXEL=                  722                                                  
+EXPTIME =                 3611 / Integration time (s)                           
+UTMIDDLE=    4.378472222222222 / UT at mid-exposure                             
+UT-DATE = '1994-02-11'         / The UT date at start of exposure               
+RELEASE = '1995-02-11T03:52:37'   / Date when the proprietary period expires    
+MJD-OBS =    49394.16153935185 / Modified JD at start of exposure               
+EXPNUM  = 'dao_r122_1994_000008' / The unique DAO archive exposure number       
+OBSTYPE = 'object  '                                                            
+HISTORY                                                                         
+COMMENT  Reticon 2.4 A/mm 40894  0 A Center                                     
+COMMENT Reticon 2.4 A                                                           
+DISPERSI=                  2.4 / Angstroms/mm                                   
+DELTA_WL=                0.036 / Approx spacing of pixels (Angstroms)           
+EQUINOX =               2000.0                                                  

--- a/dao2caom2/tests/data/dao_r122_1994_000051.expected.xml
+++ b/dao2caom2/tests/data/dao_r122_1994_000051.expected.xml
@@ -1,0 +1,120 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<caom2:Observation xmlns:caom2="http://www.opencadc.org/caom2/xml/v2.4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="caom2:SimpleObservation" caom2:id="d86c87a5-c89b-48b8-b3df-e5d7fbae1d80" caom2:metaProducer="dao2caom22caom2/0.0.0">
+  <caom2:collection>DAO</caom2:collection>
+  <caom2:observationID>dao_r122_1994_000051</caom2:observationID>
+  <caom2:metaRelease>1994-02-18T04:53:42.000</caom2:metaRelease>
+  <caom2:algorithm>
+    <caom2:name>exposure</caom2:name>
+  </caom2:algorithm>
+  <caom2:type>object</caom2:type>
+  <caom2:intent>science</caom2:intent>
+  <caom2:target>
+    <caom2:name>eta Tau</caom2:name>
+    <caom2:type>object</caom2:type>
+    <caom2:standard>false</caom2:standard>
+    <caom2:moving>false</caom2:moving>
+  </caom2:target>
+  <caom2:telescope>
+    <caom2:name>DAO 1.2-m</caom2:name>
+    <caom2:geoLocationX>-2331226.785412281</caom2:geoLocationX>
+    <caom2:geoLocationY>-3532798.9784666346</caom2:geoLocationY>
+    <caom2:geoLocationZ>4755607.337178416</caom2:geoLocationZ>
+  </caom2:telescope>
+  <caom2:instrument>
+    <caom2:name>McKellar Spectrograph</caom2:name>
+  </caom2:instrument>
+  <caom2:planes>
+    <caom2:plane caom2:id="e557781a-0a1c-4fc7-985b-0e34334709d9" caom2:metaProducer="dao2caom22caom2/0.0.0">
+      <caom2:productID>dao_r122_1994_000051</caom2:productID>
+      <caom2:metaRelease>1994-02-18T04:53:42.000</caom2:metaRelease>
+      <caom2:dataRelease>1995-02-18T04:53:42.000</caom2:dataRelease>
+      <caom2:dataProductType>spectrum</caom2:dataProductType>
+      <caom2:calibrationLevel>1</caom2:calibrationLevel>
+      <caom2:provenance>
+        <caom2:name>DAO unprocessed data</caom2:name>
+        <caom2:project>DAO Science Archive</caom2:project>
+        <caom2:producer>NRC Herzberg</caom2:producer>
+        <caom2:reference>https://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/en/dao/</caom2:reference>
+      </caom2:provenance>
+      <caom2:artifacts>
+        <caom2:artifact caom2:id="d9f71934-1fed-46f9-a46d-082cb4d2a05a" caom2:metaProducer="dao2caom22caom2/0.0.0">
+          <caom2:uri>cadc:DAO/dao_r122_1994_000051.fits</caom2:uri>
+          <caom2:productType>science</caom2:productType>
+          <caom2:releaseType>data</caom2:releaseType>
+          <caom2:contentType>application/fits</caom2:contentType>
+          <caom2:parts>
+            <caom2:part caom2:id="f990e937-f051-4f98-93e8-30fddefc4fc7">
+              <caom2:name>0</caom2:name>
+              <caom2:chunks>
+                <caom2:chunk caom2:id="9771c384-234e-454c-b9f6-ece0b83d706f" caom2:metaProducer="dao2caom22caom2/0.0.0">
+                  <caom2:observable>
+                    <caom2:dependent>
+                      <caom2:axis>
+                        <caom2:ctype>FLUX</caom2:ctype>
+                        <caom2:cunit>COUNTS</caom2:cunit>
+                      </caom2:axis>
+                      <caom2:bin>1</caom2:bin>
+                    </caom2:dependent>
+                  </caom2:observable>
+                  <caom2:position>
+                    <caom2:axis>
+                      <caom2:axis1>
+                        <caom2:ctype>RA---TAN</caom2:ctype>
+                        <caom2:cunit>deg</caom2:cunit>
+                      </caom2:axis1>
+                      <caom2:axis2>
+                        <caom2:ctype>DEC--TAN</caom2:ctype>
+                        <caom2:cunit>deg</caom2:cunit>
+                      </caom2:axis2>
+                      <caom2:function>
+                        <caom2:dimension>
+                          <caom2:naxis1>1</caom2:naxis1>
+                          <caom2:naxis2>1</caom2:naxis2>
+                        </caom2:dimension>
+                        <caom2:refCoord>
+                          <caom2:coord1>
+                            <caom2:pix>1.0</caom2:pix>
+                            <caom2:val>56.871249999999996</caom2:val>
+                          </caom2:coord1>
+                          <caom2:coord2>
+                            <caom2:pix>1.0</caom2:pix>
+                            <caom2:val>24.105000000000008</caom2:val>
+                          </caom2:coord2>
+                        </caom2:refCoord>
+                        <caom2:cd11>-0.001388</caom2:cd11>
+                        <caom2:cd12>0.0</caom2:cd12>
+                        <caom2:cd21>0.0</caom2:cd21>
+                        <caom2:cd22>0.001388</caom2:cd22>
+                      </caom2:function>
+                    </caom2:axis>
+                    <caom2:coordsys>FK5</caom2:coordsys>
+                    <caom2:equinox>2000.0</caom2:equinox>
+                  </caom2:position>
+                  <caom2:time>
+                    <caom2:axis>
+                      <caom2:axis>
+                        <caom2:ctype>TIME</caom2:ctype>
+                        <caom2:cunit>d</caom2:cunit>
+                      </caom2:axis>
+                      <caom2:function>
+                        <caom2:naxis>1</caom2:naxis>
+                        <caom2:delta>0.009039351851851852</caom2:delta>
+                        <caom2:refCoord>
+                          <caom2:pix>0.5</caom2:pix>
+                          <caom2:val>49401.20395833333</caom2:val>
+                        </caom2:refCoord>
+                      </caom2:function>
+                    </caom2:axis>
+                    <caom2:timesys>UTC</caom2:timesys>
+                    <caom2:exposure>781.0</caom2:exposure>
+                    <caom2:resolution>781.0</caom2:resolution>
+                  </caom2:time>
+                </caom2:chunk>
+              </caom2:chunks>
+            </caom2:part>
+          </caom2:parts>
+        </caom2:artifact>
+      </caom2:artifacts>
+    </caom2:plane>
+  </caom2:planes>
+</caom2:Observation>

--- a/dao2caom2/tests/data/dao_r122_1994_000051.fits.header
+++ b/dao2caom2/tests/data/dao_r122_1994_000051.fits.header
@@ -1,0 +1,36 @@
+# HDU 0 in dao_r122_1994_000051.fits:
+SIMPLE  =                    T / conforms to FITS standard                      
+BITPIX  =                   16 / array data type                                
+NAXIS   =                    2 / number of array dimensions                     
+NAXIS1  =                 2000                                                  
+NAXIS2  =                    2                                                  
+OBJECT  = 'eta Tau '           / OBJECT label                                   
+ITIME   =                  781 / OBJECT INTEGRATION TIME                        
+BTIME   =                    1 / BASELINE INTEGRATION TIME                      
+UT      = '04:53:42'           / UT at start of exposure                        
+DATE-OBS= '1994-02-18T04:53:42' / UT date/time at start of exposure             
+LMDAREF =                    0 / WAVELENGTH REFERENCE POINT                     
+PIXLREF =                    0 / CORRESPONDING PIXEL REFERENCE                  
+EXP-NBR =                   51 / ARCHIVE EXPOSURE NUMBER                        
+ORIGIN  = 'NRC HAARC'                                                           
+INSTRUME= 'McKellar Spectrograph'                                               
+TELESCOP= '1.2-m   '                                                            
+OBSERVER= 'JUGAKU  '                                                            
+DETECTOR= 'RETICON '                                                            
+PIXSIZE =                 15.0 / pixel size in microns                          
+DISPAXIS=                    1                                                  
+OBSERVAT= 'DAO     '                                                            
+OBSMODE = 'single-slit spectroscopy'                                            
+EXPTIME =                  781 / Integration time (s)                           
+UTMIDDLE=    5.003472222222221 / UT at mid-exposure                             
+UT-DATE = '1994-02-18'         / The UT date at start of exposure               
+RELEASE = '1995-02-18T04:53:42'   / Date when the proprietary period expires    
+MJD-OBS =    49401.20395833333 / Modified JD at start of exposure               
+EXPNUM  = 'dao_r122_1994_000051' / The unique DAO archive exposure number       
+OBSTYPE = 'object  '                                                            
+HISTORY                                                                         
+COMMENT  4590-4650A                                                             
+COMMENT 4590-4650A                                                              
+RA      = '03:47:29.1'         / coordinates set by CDS Sesame service          
+DEC     = '+24:06:18'          / coordinates set by CDS Sesame service          
+EQUINOX =               2000.0                                                  

--- a/dao2caom2/tests/test_broken_data.py
+++ b/dao2caom2/tests/test_broken_data.py
@@ -2,7 +2,7 @@
 # ******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 # *************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
 #
-#  (c) 2022.                            (c) 2022.
+#  (c) 2025.                            (c) 2025.
 #  Government of Canada                 Gouvernement du Canada
 #  National Research Council            Conseil national de recherches
 #  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
@@ -70,22 +70,23 @@ from os.path import basename
 
 from cadcdata import FileInfo
 from caom2pipe import astro_composable as ac
-from caom2pipe import reader_composable as rdc
+from caom2pipe.manage_composable import ExecutionReporter2
 from dao2caom2 import DAOName, fits2caom2_augmentation
 
 
-def test_failure(test_config, test_data_dir):
+def test_failure(test_config, test_data_dir, tmp_path):
+    test_config.change_working_directory(tmp_path.as_posix())
     test_fqn = f'{test_data_dir}/broken_data/dao_c122_2001_006946.fits.header'
     dao_name = DAOName(basename(test_fqn).replace('.header', '.gz'))
     file_info = FileInfo(id=dao_name.file_uri, file_type='application/fits')
     headers = ac.make_headers_from_file(test_fqn)
-    metadata_reader = rdc.FileMetadataReader()
-    metadata_reader._headers = {dao_name.file_uri: headers}
-    metadata_reader._file_info = {dao_name.file_uri: file_info}
+    dao_name.metadata = {dao_name.file_uri: headers}
+    dao_name.file_info = {dao_name.file_uri: file_info}
+    test_reporter = ExecutionReporter2(test_config)
     kwargs = {
         'storage_name': dao_name,
-        'metadata_reader': metadata_reader,
         'config': test_config,
+        'reporter': test_reporter,
     }
     observation = None
     observation = fits2caom2_augmentation.visit(observation, **kwargs)

--- a/dao2caom2/tests/test_composable.py
+++ b/dao2caom2/tests/test_composable.py
@@ -2,7 +2,7 @@
 # ******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 # *************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
 #
-#  (c) 2021.                            (c) 2021.
+#  (c) 2025.                            (c) 2025.
 #  Government of Canada                 Gouvernement du Canada
 #  National Research Council            Conseil national de recherches
 #  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
@@ -87,36 +87,31 @@ F_NAME_LIST = [
 
 @patch('cadcutils.net.ws.WsCapabilities.get_access_url')
 @patch('caom2pipe.execute_composable.OrganizeExecutes.do_one')
-def test_run(run_mock, access_mock, test_config, tmp_path):
+def test_run(run_mock, access_mock, test_config, tmp_path, change_test_dir):
     access_mock.return_value = 'https://localhost'
     test_f_id = 'test_file_id'
     test_obs_id = test_f_id
     test_f_name = f'{test_f_id}.fits'
-    orig_cwd = os.getcwd()
-    try:
-        os.chdir(tmp_path)
-        test_config.change_working_directory(tmp_path)
-        test_config.proxy_file_name = 'cadcproxy.pem'
-        test_config.write_to_file(test_config)
-        with open(test_config.proxy_fqn, 'w') as f:
-            f.write('test content')
-        with open(test_config.work_fqn, 'w') as f:
-            f.write('test_file_id.fits')
+    test_config.change_working_directory(tmp_path)
+    test_config.proxy_file_name = 'cadcproxy.pem'
+    test_config.write_to_file(test_config)
+    with open(test_config.proxy_fqn, 'w') as f:
+        f.write('test content')
+    with open(test_config.work_fqn, 'w') as f:
+        f.write('test_file_id.fits')
 
-        # execution
-        composable._run()
+    # execution
+    composable._run()
 
-        assert run_mock.called, 'should have been called'
-        args, kwargs = run_mock.call_args
-        test_storage = args[0]
-        assert isinstance(test_storage, dao_name.DAOName), type(test_storage)
-        assert test_storage.obs_id == test_obs_id, 'wrong obs id'
-        assert test_storage.file_name == test_f_name, 'wrong file name'
-        assert (
-            test_storage.destination_uris[0] == f'{test_config.scheme}:{test_config.collection}/{test_f_name}'
-        ), 'wrong destination uri'
-    finally:
-        os.chdir(orig_cwd)
+    assert run_mock.called, 'should have been called'
+    args, _ = run_mock.call_args
+    test_storage = args[0]
+    assert isinstance(test_storage, dao_name.DAOName), type(test_storage)
+    assert test_storage.obs_id == test_obs_id, 'wrong obs id'
+    assert test_storage.file_name == test_f_name, 'wrong file name'
+    assert (
+        test_storage.destination_uris[0] == f'{test_config.scheme}:{test_config.collection}/{test_f_name}'
+    ), 'wrong destination uri'
 
 
 @patch('cadcutils.net.ws.WsCapabilities.get_access_url')
@@ -154,13 +149,13 @@ def test_run_vo(run_mock, vo_client_mock, access_mock, test_data_dir):
                 os.unlink(fqn)
 
 
-@patch('caom2utils.data_util.get_local_headers_from_fits')
-@patch('caom2utils.data_util.get_local_file_info')
-@patch('caom2pipe.execute_composable.CaomExecute._caom2_store')
-@patch('caom2pipe.execute_composable.CaomExecute._visit_meta')
-@patch('caom2pipe.execute_composable.CaomExecute._visit_data')
-@patch('caom2pipe.data_source_composable.LocalFilesDataSource.clean_up')
-@patch('caom2pipe.data_source_composable.LocalFilesDataSource.get_work')
+@patch('caom2pipe.execute_composable.get_local_file_info')
+@patch('caom2pipe.execute_composable.get_local_file_headers')
+@patch('caom2pipe.execute_composable.CaomExecuteRunnerMeta._caom2_store')
+@patch('caom2pipe.execute_composable.CaomExecuteRunnerMeta._visit_meta')
+@patch('caom2pipe.execute_composable.CaomExecuteRunnerMeta._visit_data')
+@patch('caom2pipe.data_source_composable.LocalFilesDataSourceRunnerMeta.clean_up')
+@patch('caom2pipe.data_source_composable.LocalFilesDataSourceRunnerMeta.get_work')
 @patch('caom2pipe.client_composable.ClientCollection', autospec=True)
 def test_run_store_ingest(
     clients_mock,
@@ -169,24 +164,26 @@ def test_run_store_ingest(
     visit_data_mock,
     visit_meta_mock,
     caom2_store_mock,
-    reader_headers_mock,
-    reader_file_info_mock,
+    headers_mock,
+    file_info_mock,
     test_config,
     tmp_path,
+    change_test_dir,
 ):
     temp_deque = deque()
-    temp_deque.append('/data/dao_c122_2021_005157_e.fits')
-    temp_deque.append('/data/dao_c122_2021_005157.fits')
+    test_storage_name_1 = dao_name.DAOName(['/data/dao_c122_2021_005157_e.fits'])
+    test_storage_name_2 = dao_name.DAOName(['/data/dao_c122_2021_005157.fits'])
+    temp_deque.append(test_storage_name_1)
+    temp_deque.append(test_storage_name_2)
     get_work_mock.return_value = temp_deque
     clients_mock.return_value.metadata_client.read.return_value = None
-    reader_headers_mock.return_value = [{'OBSMODE': 'abc'}]
+    cleanup_mock.return_value = True
+    headers_mock.return_value = [{'OBSMODE': 'abc'}]
 
     def _file_info_mock(key):
         return FileInfo(id=key, file_type='application/fits', md5sum='def')
 
-    reader_file_info_mock.side_effect = _file_info_mock
-    cwd = os.getcwd()
-    os.chdir(tmp_path)
+    file_info_mock.side_effect = _file_info_mock
     test_config.change_working_directory(tmp_path)
     test_config.task_types = [mc.TaskType.STORE, mc.TaskType.INGEST]
     test_config.use_local_files = True
@@ -201,58 +198,52 @@ def test_run_store_ingest(
     test_config.write_to_file(test_config)
     with open(test_config.proxy_fqn, 'w') as f:
         f.write('test content')
-    getcwd_orig = os.getcwd
-    os.getcwd = Mock(return_value=tmp_path)
-    try:
-        test_result = composable._run()
-        assert test_result is not None, 'expect result'
-        assert test_result == 0, 'expect success'
-        assert clients_mock.return_value.metadata_client.read.called, 'read called'
-        # make sure data is not really being written to CADC storage :)
-        assert clients_mock.return_value.data_client.put.called, 'put should be called'
-        assert clients_mock.return_value.data_client.put.call_count == 2, 'wrong number of puts'
-        put_calls = [
-            call('/data', 'cadc:DAOCADC/dao_c122_2021_005157_e.fits'),
-            call('/data', 'cadc:DAO/dao_c122_2021_005157.fits'),
-        ]
-        clients_mock.return_value.data_client.put.assert_has_calls(put_calls, any_order=False)
-        assert cleanup_mock.called, 'cleanup'
-        cleanup_calls = [
-            call('/data/dao_c122_2021_005157_e.fits', 0, 0),
-            call('/data/dao_c122_2021_005157.fits', 0, 0),
-        ]
-        cleanup_mock.assert_has_calls(cleanup_calls), 'wrong cleanup args'
-        assert visit_meta_mock.called, '_visit_meta call'
-        assert visit_meta_mock.call_count == 2, '_visit_meta call count'
-        assert visit_data_mock.called, '_visit_data call'
-        assert visit_data_mock.call_count == 2, '_visit_data call count'
-        assert caom2_store_mock.called, '_caom2_store call'
-        assert caom2_store_mock.call_count == 2, '_caom2_store call count'
-        assert reader_file_info_mock.called, 'info'
-        assert reader_file_info_mock.call_count == 2, 'wrong number of info calls'
-        reader_info_calls = [
-            call('/data/dao_c122_2021_005157_e.fits'),
-            call('/data/dao_c122_2021_005157.fits'),
-        ]
-        reader_file_info_mock.assert_has_calls(reader_info_calls), 'info'
-        assert reader_headers_mock.called, 'get_head should be called'
-        assert reader_headers_mock.call_count == 2, 'get_head call count'
-        header_calls = [
-            call('/data/dao_c122_2021_005157_e.fits'),
-            call('/data/dao_c122_2021_005157.fits'),
-        ]
-        reader_headers_mock.assert_has_calls(header_calls), 'get_head'
-    finally:
-        os.getcwd = getcwd_orig
-        os.chdir(cwd)
+    test_result = composable._run()
+    assert test_result is not None, 'expect result'
+    assert test_result == 0, 'expect success'
+    assert clients_mock.return_value.metadata_client.read.called, 'read called'
+    # make sure data is not really being written to CADC storage :)
+    assert clients_mock.return_value.data_client.put.called, 'put should be called'
+    assert clients_mock.return_value.data_client.put.call_count == 2, 'wrong number of puts'
+    put_calls = [
+        call('/data', 'cadc:DAOCADC/dao_c122_2021_005157_e.fits'),
+        call('/data', 'cadc:DAO/dao_c122_2021_005157.fits'),
+    ]
+    clients_mock.return_value.data_client.put.assert_has_calls(put_calls, any_order=False)
+    assert cleanup_mock.called, 'cleanup'
+    cleanup_calls = [
+        call(test_storage_name_1, 0, 0),
+        call(test_storage_name_2, 0, 0),
+    ]
+    cleanup_mock.assert_has_calls(cleanup_calls), 'wrong cleanup args'
+    assert visit_meta_mock.called, '_visit_meta call'
+    assert visit_meta_mock.call_count == 2, '_visit_meta call count'
+    assert visit_data_mock.called, '_visit_data call'
+    assert visit_data_mock.call_count == 2, '_visit_data call count'
+    assert caom2_store_mock.called, '_caom2_store call'
+    assert caom2_store_mock.call_count == 2, '_caom2_store call count'
+    assert file_info_mock.called, 'info'
+    assert file_info_mock.call_count == 2, 'wrong number of info calls'
+    reader_info_calls = [
+        call('/data/dao_c122_2021_005157_e.fits'),
+        call('/data/dao_c122_2021_005157.fits'),
+    ]
+    file_info_mock.assert_has_calls(reader_info_calls), 'info'
+    assert headers_mock.called, 'get_head should be called'
+    assert headers_mock.call_count == 2, 'get_head call count'
+    header_calls = [
+        call('/data/dao_c122_2021_005157_e.fits'),
+        call('/data/dao_c122_2021_005157.fits'),
+    ]
+    headers_mock.assert_has_calls(header_calls), 'get_head'
 
 
 @patch('caom2pipe.astro_composable.check_fitsverify')
-@patch('caom2utils.data_util.get_local_file_headers')
+@patch('caom2pipe.execute_composable.get_local_file_headers')
 @patch('dao2caom2.composable.Client')
-@patch('caom2pipe.execute_composable.CaomExecute._caom2_store')
-@patch('caom2pipe.execute_composable.CaomExecute._visit_meta')
-@patch('caom2pipe.execute_composable.CaomExecute._visit_data')
+@patch('caom2pipe.execute_composable.CaomExecuteRunnerMeta._caom2_store')
+@patch('caom2pipe.execute_composable.CaomExecuteRunnerMeta._visit_meta')
+@patch('caom2pipe.execute_composable.CaomExecuteRunnerMeta._visit_data')
 @patch('dao2caom2.data_source.DAOVaultDataSource.clean_up')
 @patch('caom2pipe.client_composable.ClientCollection', autospec=True)
 def test_run_store_ingest_remote(
@@ -266,9 +257,11 @@ def test_run_store_ingest_remote(
     verify_mock,
     test_config,
     tmp_path,
+    change_test_dir,
 ):
     vo_mock.return_value.listdir.return_value = ['dao_c122_2021_005157_e.fits', 'dao_c122_2021_005157.fits']
     vo_mock.return_value.isdir.return_value = False
+    cleanup_mock.return_value = True
     clients_mock.return_value.metadata_client.read.return_value = None
     file_headers_mock.return_value = [{'OBSMODE': 'abc'}]
 
@@ -286,9 +279,7 @@ def test_run_store_ingest_remote(
 
     clients_mock.return_value.data_client.info.side_effect = _file_info_mock
     verify_mock.return_value = True
-    cwd = os.getcwd()
-    os.chdir(tmp_path)
-    test_config.working_directory = tmp_path
+    test_config.change_working_directory(tmp_path.as_posix())
     test_config.task_types = [mc.TaskType.STORE, mc.TaskType.INGEST]
     test_config.use_local_files = False
     test_config.cleanup_files_when_storing = False
@@ -297,96 +288,79 @@ def test_run_store_ingest_remote(
     test_config.data_source_extensions = ['.fits']
     test_config.logging_level = 'INFO'
     test_config.proxy_file_name = 'cadcproxy.pem'
-    test_config.proxy_fqn = f'{tmp_path}/cadcproxy.pem'
     test_config.recurse_data_sources = False
     mc.Config.write_to_file(test_config)
     with open(test_config.proxy_fqn, 'w') as f:
         f.write('test content')
-    getcwd_orig = os.getcwd
-    os.getcwd = Mock(return_value=tmp_path)
-    try:
-        test_result = composable._run_vo()
-        assert test_result is not None, 'expect result'
-        assert test_result == 0, 'expect success'
-        assert clients_mock.return_value.metadata_client.read.called, 'read called'
-        # make sure data is not really being written to CADC storage :)
-        assert clients_mock.return_value.data_client.put.called, 'put should be called'
-        assert clients_mock.return_value.data_client.put.call_count == 2, 'wrong number of puts'
-        put_calls = [
-            call(f'{tmp_path}/dao_c122_2021_005157', 'cadc:DAOCADC/dao_c122_2021_005157_e.fits'),
-            call(f'{tmp_path}/dao_c122_2021_005157', 'cadc:DAO/dao_c122_2021_005157.fits'),
-        ]
-        clients_mock.return_value.data_client.put.assert_has_calls(put_calls, any_order=False)
-        assert clients_mock.return_value.data_client.info.called, 'info should be called'
-        assert clients_mock.return_value.data_client.info.call_count == 2, 'wrong number of infos'
-        info_calls = [call('cadc:DAOCADC/dao_c122_2021_005157_e.fits'), call('cadc:DAO/dao_c122_2021_005157.fits')]
-        clients_mock.return_value.data_client.info.assert_has_calls(info_calls, any_order=False)
-        assert cleanup_mock.called, 'cleanup'
-        cleanup_calls = [
-            call('vos:goliaths/DAOtest/dao_c122_2021_005157_e.fits', 0, 0),
-            call('vos:goliaths/DAOtest/dao_c122_2021_005157.fits', 0, 0),
-        ]
-        cleanup_mock.assert_has_calls(cleanup_calls), 'wrong cleanup args'
-        assert vo_mock.return_value.copy.called, 'copy'
-        copy_calls = [
-            call(
-                'vos:goliaths/DAOtest/dao_c122_2021_005157_e.fits',
-                f'{tmp_path}/dao_c122_2021_005157/dao_c122_2021_005157_e.fits',
-                send_md5=True,
-            ),
-            call('vos:goliaths/DAOtest/dao_c122_2021_005157_e.fits', ANY, head=True),
-            call(
-                'vos:goliaths/DAOtest/dao_c122_2021_005157.fits',
-                f'{tmp_path}/dao_c122_2021_005157/dao_c122_2021_005157.fits',
-                send_md5=True,
-            ),
-            call('vos:goliaths/DAOtest/dao_c122_2021_005157.fits', ANY, head=True),
-        ]
-        vo_mock.return_value.copy.assert_has_calls(copy_calls), 'wrong vo copy parameters'
-        assert visit_meta_mock.called, '_visit_meta call'
-        assert visit_meta_mock.call_count == 2, '_visit_meta call count'
-        assert visit_data_mock.called, '_visit_data call'
-        assert visit_data_mock.call_count == 2, '_visit_data call count'
-        assert caom2_store_mock.called, '_caom2_store call'
-        assert caom2_store_mock.call_count == 2, '_caom2_store call count'
-        assert vo_mock.return_value.get_node.called, 'get_node'
-        assert vo_mock.return_value.get_node.call_count == 2, 'wrong number of get_node calls'
-        reader_info_calls = [
-            call('vos:goliaths/DAOtest/dao_c122_2021_005157_e.fits', limit=None, force=False),
-            call('vos:goliaths/DAOtest/dao_c122_2021_005157.fits', limit=None, force=False),
-        ]
-        vo_mock.return_value.get_node.assert_has_calls(reader_info_calls), 'get_node calls'
-        assert file_headers_mock.called, 'get_head should be called'
-        assert file_headers_mock.call_count == 2, 'get_head call count'
-        header_calls = [call(ANY), call(ANY)]
-        file_headers_mock.assert_has_calls(header_calls), 'get_head'
-    finally:
-        os.getcwd = getcwd_orig
-        os.chdir(cwd)
+    test_result = composable._run_vo()
+    assert test_result is not None, 'expect result'
+    assert test_result == 0, 'expect success'
+    assert clients_mock.return_value.metadata_client.read.called, 'read called'
+    # make sure data is not really being written to CADC storage :)
+    assert clients_mock.return_value.data_client.put.called, 'put should be called'
+    assert clients_mock.return_value.data_client.put.call_count == 2, 'wrong number of puts'
+    put_calls = [
+        call(f'{tmp_path}/dao_c122_2021_005157', 'cadc:DAOCADC/dao_c122_2021_005157_e.fits'),
+        call(f'{tmp_path}/dao_c122_2021_005157', 'cadc:DAO/dao_c122_2021_005157.fits'),
+    ]
+    clients_mock.return_value.data_client.put.assert_has_calls(put_calls, any_order=False)
+    assert clients_mock.return_value.data_client.info.called, 'info should be called'
+    assert clients_mock.return_value.data_client.info.call_count == 2, 'wrong number of infos'
+    info_calls = [call('cadc:DAOCADC/dao_c122_2021_005157_e.fits'), call('cadc:DAO/dao_c122_2021_005157.fits')]
+    clients_mock.return_value.data_client.info.assert_has_calls(info_calls, any_order=False)
+    assert cleanup_mock.called, 'cleanup'
+    cleanup_calls = [call(ANY, 0, 0), call(ANY, 0, 0)]
+    cleanup_mock.assert_has_calls(cleanup_calls), 'wrong cleanup args'
+    assert vo_mock.return_value.copy.called, 'copy'
+    copy_calls = [
+        call(
+            'vos:goliaths/DAOtest/dao_c122_2021_005157_e.fits',
+            f'{tmp_path}/dao_c122_2021_005157/dao_c122_2021_005157_e.fits',
+            send_md5=True,
+        ),
+        call(
+            'vos:goliaths/DAOtest/dao_c122_2021_005157.fits',
+            f'{tmp_path}/dao_c122_2021_005157/dao_c122_2021_005157.fits',
+            send_md5=True,
+        ),
+    ]
+    vo_mock.return_value.copy.assert_has_calls(copy_calls), 'wrong vo copy parameters'
+    assert visit_meta_mock.called, '_visit_meta call'
+    assert visit_meta_mock.call_count == 2, '_visit_meta call count'
+    assert visit_data_mock.called, '_visit_data call'
+    assert visit_data_mock.call_count == 2, '_visit_data call count'
+    assert caom2_store_mock.called, '_caom2_store call'
+    assert caom2_store_mock.call_count == 2, '_caom2_store call count'
+    assert vo_mock.return_value.get_node.called, 'get_node'
+    assert vo_mock.return_value.get_node.call_count == 2, 'wrong number of get_node calls'
+    reader_info_calls = [
+        call('vos:goliaths/DAOtest/dao_c122_2021_005157_e.fits', limit=None, force=False),
+        call('vos:goliaths/DAOtest/dao_c122_2021_005157.fits', limit=None, force=False),
+    ]
+    vo_mock.return_value.get_node.assert_has_calls(reader_info_calls), 'get_node calls'
+    assert file_headers_mock.called, 'get_head should be called'
+    assert file_headers_mock.call_count == 2, 'get_head call count'
+    header_calls = [call(ANY), call(ANY)]
+    file_headers_mock.assert_has_calls(header_calls), 'get_head'
 
 
 @patch('cadcutils.net.ws.WsCapabilities.get_access_url')
 @patch('caom2pipe.execute_composable.OrganizeExecutes.do_one')
-def test_run_state(run_mock, access_mock, test_config, tmp_path):
+def test_run_state(run_mock, access_mock, test_config, tmp_path, change_test_dir):
     access_mock.return_value = 'https://localhost'
     test_f_id = 'test_file_id'
-    test_obs_id = test_f_id
-    test_f_name = f'{test_f_id}.fits'
-    orig_cwd = os.getcwd()
-    try:
-        os.chdir(tmp_path)
-        test_config.change_working_directory(tmp_path)
-        test_config.proxy_file_name = 'cadcproxy.pem'
-        test_config.write_to_file(test_config)
-        now_dt = datetime.now()
-        five_minutes_ago_dt = now_dt - timedelta(minutes=5)
-        with open(test_config.proxy_fqn, 'w') as f:
-            f.write('test content')
-        mc.State.write_bookmark(test_config.state_fqn, test_config.bookmark, five_minutes_ago_dt)
+    # test_obs_id = test_f_id
+    # test_f_name = f'{test_f_id}.fits'
+    test_config.change_working_directory(tmp_path)
+    test_config.proxy_file_name = 'cadcproxy.pem'
+    test_config.write_to_file(test_config)
+    now_dt = datetime.now()
+    five_minutes_ago_dt = now_dt - timedelta(minutes=5)
+    with open(test_config.proxy_fqn, 'w') as f:
+        f.write('test content')
+    mc.State.write_bookmark(test_config.state_fqn, test_config.bookmark, five_minutes_ago_dt)
 
-        # execution
-        test_result = composable._run_state()
-        assert test_result == 0, 'expect success'
-        assert not run_mock.called, 'should not have been called'
-    finally:
-        os.chdir(orig_cwd)
+    # execution
+    test_result = composable._run_state()
+    assert test_result == 0, 'expect success'
+    assert not run_mock.called, 'should not have been called'

--- a/dao2caom2/tests/test_preview_augmentation.py
+++ b/dao2caom2/tests/test_preview_augmentation.py
@@ -2,7 +2,7 @@
 # ******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 # *************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
 #
-#  (c) 2020.                            (c) 2020.
+#  (c) 2025.                            (c) 2025.
 #  Government of Canada                 Gouvernement du Canada
 #  National Research Council            Conseil national de recherches
 #  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
@@ -70,12 +70,8 @@ import os
 
 from caom2pipe import manage_composable as mc
 from dao2caom2 import preview_augmentation, dao_name
-import test_caom_gen_visit
 
 TEST_FILES_DIR = '/test_files'
-# REJECTED_FILE = os.path.join(
-#     test_caom_gen_visit.TEST_DATA_DIR, 'rejected.yml'
-# )
 
 
 def test_visit(test_config, test_data_dir, tmp_path):
@@ -146,7 +142,7 @@ def test_visit(test_config, test_data_dir, tmp_path):
     for key, value in test_files.items():
         obs = mc.read_obs_from_file(f'{test_data_dir}/previews/{key}')
         for f_name in value:
-            test_name = dao_name.DAOName(f_name)
+            test_name = dao_name.DAOName([f_name])
             kwargs['storage_name'] = test_name
 
             try:

--- a/dao2caom2/tests/test_storage_name.py
+++ b/dao2caom2/tests/test_storage_name.py
@@ -1,9 +1,8 @@
-# -*- coding: utf-8 -*-
 # ***********************************************************************
 # ******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 # *************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
 #
-#  (c) 2018.                            (c) 2018.
+#  (c) 2025.                            (c) 2025.
 #  Government of Canada                 Gouvernement du Canada
 #  National Research Council            Conseil national de recherches
 #  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
@@ -71,11 +70,11 @@ from dao2caom2 import DAOName, PRODUCT_COLLECTION
 
 
 def test_is_valid():
-    assert DAOName('anything').is_valid()
+    assert DAOName(['anything']).is_valid()
 
 
 def test_processed(test_config):
-    test_subject = DAOName('dao_c122_2020_004100_v.fits.gz')
+    test_subject = DAOName(['dao_c122_2020_004100_v.fits.gz'])
     assert test_subject is not None, 'expect a value'
     assert test_subject.obs_id == 'dao_c122_2020_004100', 'wrong obs id'
     assert test_subject.file_name == 'dao_c122_2020_004100_v.fits.gz', 'wrong file name'
@@ -92,7 +91,7 @@ def test_processed(test_config):
 
 
 def test_raw(test_config):
-    test_result = DAOName('cadc:DAO/dao_c182_2018_015013.fits')
+    test_result = DAOName(['cadc:DAO/dao_c182_2018_015013.fits'])
     assert test_result is not None, 'expect a result'
     assert test_result.obs_id == 'dao_c182_2018_015013'
     assert test_result.file_name == 'dao_c182_2018_015013.fits'
@@ -102,7 +101,7 @@ def test_raw(test_config):
         f'{test_config.scheme}:{test_config.collection}/dao_c182_2018_015013.fits'
     ], 'wrong destination uris'
 
-    test_result_2 = DAOName('/usr/src/app/dao_c182_2018_015013/dao_c182_2018_015013.fits.gz')
+    test_result_2 = DAOName(['/usr/src/app/dao_c182_2018_015013/dao_c182_2018_015013.fits.gz'])
     assert test_result_2.source_names == ['/usr/src/app/dao_c182_2018_015013/dao_c182_2018_015013.fits.gz']
     assert test_result_2.destination_uris == [
         f'{test_config.scheme}:{test_config.collection}/dao_c182_2018_015013.fits'


### PR DESCRIPTION
…pixel size with the value from the fits header, plus changes based on using the RunnerMeta structure as a return value from the DataSource specializations, this replacing and removing the MetadataReader and NameBuilder classes.