### PR TITLE
Update organization references in documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update --no-install-recommends  && apt-get dist-upgrade -y && \
     rm -rf /var/lib/apt/lists/ /tmp/* /var/tmp/* 
 
 ARG OPENCADC_BRANCH=main
-ARG OPENCADC_REPO=opencadc
+ARG OPENCADC_REPO=opencadc-metadata-curation
 
 WORKDIR /usr/src/app
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ In an empty directory (the 'working directory'), on a machine with Docker instal
 1. In the master branch of this repository, one time only, find the scripts directory, and copy the file dao_run.sh to the working directory. e.g.:
 
    ```
-   wget https://raw.github.com/opencadc/dao2caom2/master/scripts/dao_run.sh
+   wget https://raw.github.com/opencadc-metadata-curation/dao2caom2/master/scripts/dao_run.sh
    ```
 
 1. Ensure the script is executable, one time only:
@@ -48,7 +48,7 @@ In an empty directory (the 'working directory'), on a machine with Docker instal
 1. In the master branch of this repository, find the scripts directory, and copy the file dao_run_state.sh to the working directory. e.g.:
 
   ```
-  wget https://raw.github.com/opencadc/dao2caom2/master/scripts/dao_run_state.sh
+  wget https://raw.github.com/opencadc-metadata-curation/dao2caom2/master/scripts/dao_run_state.sh
   ```
 
 2. Ensure the script is executable:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ In an empty directory (the 'working directory'), on a machine with Docker instal
     ./dao_run.sh
     ```
     
-1. The config.yml file will be created in the 'working directory'. This file controls the execution of the application. See [here](https://github.com/opencadc/collection2caom2/wiki/config.yml) for a description of the entries in this file.
+1. The config.yml file will be created in the 'working directory'. This file controls the execution of the application. See [here](https://github.com/opencadc-metadata-curation/collection2caom2/wiki/config.yml) for a description of the entries in this file.
 
 1. To debug the application from inside the container:
 
@@ -37,9 +37,9 @@ In an empty directory (the 'working directory'), on a machine with Docker instal
    ```
 
 1. For some instructions that might be helpful on using containers, see:
-https://github.com/opencadc/collection2caom2/wiki/Docker-and-Collections
+https://github.com/opencadc-metadata-curation/collection2caom2/wiki/Docker-and-Collections
 
-1. For some insight into what's happening, see: https://github.com/opencadc/collection2caom2
+1. For some insight into what's happening, see: https://github.com/opencadc-metadata-curation/collection2caom2
 
 # How to Run dao2caom2 incrementally:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ author_email = cadc@nrc-cnrc.gc.ca
 license = AGPLv3
 url = TBD
 edit_on_github = False
-github_project = opencadc/dao2caom2
+github_project = opencadc-metadata-curation/dao2caom2
 install_requires = 
   cadcdata 
   cadctap 


### PR DESCRIPTION
Update GitHub URLs in documentation from `opencadc` to `opencadc-metadata-curation` following repository transfer.

**Note:** Docker image references are not changed in this PR.